### PR TITLE
added 'Actions (active)' option

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -9,6 +9,8 @@
 	overflow: hidden;
 	word-wrap: break-word;
 	cursor: help;
+	position: relative;
+	z-index: 1000;
 }
 
 .wordpress_hook { 


### PR DESCRIPTION
New option shows only those hooks that are currently in use. Handy when modifying a 3rd party theme, where you want to find and modify existing elements.

![Sample output](https://cloud.githubusercontent.com/assets/2739217/16180544/94156a02-36cb-11e6-9aaa-cefebdde1e0d.png)
