### PR TITLE
Don't show admin bar if Genesis is not active.

### DIFF
--- a/genesis-visual-hook-guide.php
+++ b/genesis-visual-hook-guide.php
@@ -37,10 +37,11 @@ function gvhg_active_notice() { ?>
 
 add_action( 'admin_bar_menu', 'gvhg_admin_bar_links', 100 );
 function gvhg_admin_bar_links() {
-global $wp_admin_bar;
+	global $wp_admin_bar;
 
-	if ( is_admin() )
+	if ( is_admin() || false === function_exists( 'genesis' ) ) {
 		return;
+	}
 
 	$wp_admin_bar->add_menu(
 		array(


### PR DESCRIPTION
If you switch to a non-Genesis theme, the Genesis Hooks menu bar still appears. I modified the conditional statement to return early if Genesis is not active.